### PR TITLE
Enabling proximity wake-up

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -363,4 +363,10 @@
 
     <!-- Operating volatage for bluetooth controller. 0 by default-->
     <integer translatable="false" name="config_bluetooth_operating_voltage_mv">3300</integer>
+    
+    <!-- Default value for proximity check on screen wake
+         NOTE ! - Enable for devices that have a fast response proximity sensor (ideally < 300ms)-->
+    <bool name="config_proximityCheckOnWake">true</bool>
+    <integer name="config_proximityCheckTimeout">200</integer> <!-- Maybe there should be lower/higher timeout. I don't have build machine to compile & check-->
+    <bool name="config_proximityCheckOnWakeEnabledByDefault">false</bool>
 </resources>


### PR DESCRIPTION
I suppose this should enable (at least start showing toggle in settings) "Proximity wake-up" feature? I don't see a reason why it's disabled (not in config) now. Keeping phone in pocket is a mess without it.

NOTE: I didn't compiled that. Not sure if it works or even doesn't break anything.
