### PR TITLE
Updated for CM-14.0

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -160,7 +160,7 @@ BOARD_LIGHTS_VARIANT := aw2013
 TARGET_PROVIDES_LIBLIGHT := true
 
 # Malloc
-MALLOC_IMPL := dlmalloc
+MALLOC_SVELTE := true
 
 # Peripheral manager
 TARGET_PER_MGR_ENABLED := true


### PR DESCRIPTION
Changes to overcome this error `uild/core/envsetup.mk:161: *** Unsupported option MALLOC_IMPL defined by board config: device/xiaomi/kenzo/BoardConfig.mk.
build/core/envsetup.mk:162: *** Use`MALLOC_SVELTE := true`to configure jemalloc for low-memory.  Stop.
build/core/envsetup.mk:161: *** Unsupported option MALLOC_IMPL defined by board config: device/xiaomi/kenzo/BoardConfig.mk.
build/core/envsetup.mk:162: *** Use`MALLOC_SVELTE := true`to configure jemalloc for low-memory.  Stop.`
